### PR TITLE
Remove the `#[non_exhaustive]` attribute on most structs

### DIFF
--- a/perf-event-open-sys/Cargo.toml
+++ b/perf-event-open-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event-open-sys2"
-version = "5.0.1"
+version = "5.0.2"
 description = """
 Unsafe, direct bindings for Linux's perf_event_open system call, with associated
 types and constants.

--- a/perf-event-open-sys/src/bindings_aarch64.rs
+++ b/perf-event-open-sys/src/bindings_aarch64.rs
@@ -1988,7 +1988,6 @@ impl perf_event_attr {
 }
 #[repr(C)]
 #[derive(Debug, Default)]
-#[non_exhaustive]
 pub struct perf_event_query_bpf {
     pub ids_len: __u32,
     pub prog_cnt: __u32,
@@ -2551,7 +2550,6 @@ impl ::std::fmt::Debug for perf_event_mmap_page {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_event_header {
     pub type_: __u32,
     pub misc: __u16,
@@ -2604,7 +2602,6 @@ fn bindgen_test_layout_perf_event_header() {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_ns_link_info {
     pub dev: __u64,
     pub ino: __u64,
@@ -2703,7 +2700,6 @@ pub union perf_mem_data_src {
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_mem_data_src__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -2947,7 +2943,6 @@ impl ::std::fmt::Debug for perf_mem_data_src {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_branch_entry {
     pub from: __u64,
     pub to: __u64,
@@ -3166,7 +3161,6 @@ pub union perf_sample_weight {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_sample_weight__bindgen_ty_1 {
     pub var1_dw: __u32,
     pub var2_w: __u16,

--- a/perf-event-open-sys/src/bindings_x86_64.rs
+++ b/perf-event-open-sys/src/bindings_x86_64.rs
@@ -2032,7 +2032,6 @@ impl perf_event_attr {
 }
 #[repr(C)]
 #[derive(Debug, Default)]
-#[non_exhaustive]
 pub struct perf_event_query_bpf {
     pub ids_len: __u32,
     pub prog_cnt: __u32,
@@ -2595,7 +2594,6 @@ impl ::std::fmt::Debug for perf_event_mmap_page {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_event_header {
     pub type_: __u32,
     pub misc: __u16,
@@ -2648,7 +2646,6 @@ fn bindgen_test_layout_perf_event_header() {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_ns_link_info {
     pub dev: __u64,
     pub ino: __u64,
@@ -2747,7 +2744,6 @@ pub union perf_mem_data_src {
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_mem_data_src__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -2991,7 +2987,6 @@ impl ::std::fmt::Debug for perf_mem_data_src {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_branch_entry {
     pub from: __u64,
     pub to: __u64,
@@ -3210,7 +3205,6 @@ pub union perf_sample_weight {
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
-#[non_exhaustive]
 pub struct perf_sample_weight__bindgen_ty_1 {
     pub var1_dw: __u32,
     pub var2_w: __u16,


### PR DESCRIPTION
As it turns out, it is only really needed for a few key structs. In addition, having these extra structs be #[non_exhaustive] is rather inconvenient.