### PR TITLE
Add support for parsing `Record`s via the `perf_event_data` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,8 @@ members = [
     "perf-event-open-sys",
 ]
 resolver = "2"
+
+# perf-event-data depends on perf-event-open-sys2 but we want it to use our
+# local version when doing dev work.
+[patch.crates-io]
+perf-event-open-sys2 = { path = "perf-event-open-sys"}

--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event2"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Rust interface to Linux performance monitoring"
 license = "MIT OR Apache-2.0"
 authors = ["Sean Lynch <sean@lynches.ca>", "Jim Blandy <jimb@red-bean.com>"]
@@ -27,9 +27,9 @@ default = []
 bitflags = "2.1"
 libc = "0.2"
 memmap2 = "0.5"
+perf-event-data = "0.1"
 
 [dependencies.perf-event-open-sys2]
-path = "../perf-event-open-sys"
 version = "5.0"
 
 [dev-dependencies]

--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -27,7 +27,7 @@ default = []
 bitflags = "2.1"
 libc = "0.2"
 memmap2 = "0.5"
-perf-event-data = "0.1"
+perf-event-data = "0.1.1"
 
 [dependencies.perf-event-open-sys2]
 version = "5.0"

--- a/perf-event/src/builder.rs
+++ b/perf-event/src/builder.rs
@@ -5,6 +5,7 @@ use std::os::raw::{c_int, c_ulong};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use libc::pid_t;
+use perf_event_data::parse::ParseConfig;
 
 use crate::events::Event;
 use crate::sys::bindings::perf_event_attr;
@@ -157,10 +158,7 @@ impl<'a> Builder<'a> {
     /// [`enable_on_exec`]: Builder::enable_on_exec
     /// [0]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
     pub fn build(&self) -> std::io::Result<Counter> {
-        Counter::new_internal(
-            self.build_impl(None)?,
-            ReadFormat::from_bits_retain(self.attrs.read_format),
-        )
+        Counter::new_internal(self.build_impl(None)?, ParseConfig::from(self.attrs))
     }
 
     /// Construct a [`Counter`] as part of a group.
@@ -213,7 +211,7 @@ impl<'a> Builder<'a> {
             .checked_add(1)
             .expect("cannot add more than u32::MAX elements to a group");
 
-        Counter::new_internal(file, ReadFormat::from_bits_retain(self.attrs.read_format))
+        Counter::new_internal(file, ParseConfig::from(self.attrs))
     }
 
     /// Build a [`Group`] according to the specifications made on this

--- a/perf-event/src/flags.rs
+++ b/perf-event/src/flags.rs
@@ -1,115 +1,43 @@
-use bitflags::bitflags;
-
-use crate::sys::bindings;
 use crate::Builder;
-
-pub use self::bitflag_defs::*;
+use crate::ReadFormat;
 
 used_in_docs!(Builder);
 
-// Temporary, until all the bitflag fields are documented.
-#[allow(missing_docs)]
-mod bitflag_defs {
-    use super::*;
+pub(crate) trait ReadFormatExt: Sized {
+    const MAX_NON_GROUP_SIZE: usize;
+    fn prefix_len(&self) -> usize;
+    fn element_len(&self) -> usize;
+}
 
-    bitflags! {
-        /// Specifies which fields to include in the sample.
-        ///
-        /// These values correspond to `PERF_SAMPLE_x` values. See the
-        /// [manpage] for documentation on what they mean.
-        ///
-        /// [manpage]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
-        #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
-        pub struct SampleFlag : u64 {
-            const IP = bindings::PERF_SAMPLE_IP as _;
-            const TID = bindings::PERF_SAMPLE_TID as _;
-            const TIME = bindings::PERF_SAMPLE_TIME as _;
-            const ADDR = bindings::PERF_SAMPLE_ADDR as _;
-            const READ = bindings::PERF_SAMPLE_READ as _;
-            const CALLCHAIN = bindings::PERF_SAMPLE_CALLCHAIN as _;
-            const ID = bindings::PERF_SAMPLE_ID as _;
-            const CPU = bindings::PERF_SAMPLE_CPU as _;
-            const PERIOD = bindings::PERF_SAMPLE_PERIOD as _;
-            const STREAM_ID = bindings::PERF_SAMPLE_STREAM_ID as _;
-            const RAW = bindings::PERF_SAMPLE_RAW as _;
-            const BRANCH_STACK = bindings::PERF_SAMPLE_BRANCH_STACK as _;
-            const REGS_USER = bindings::PERF_SAMPLE_REGS_USER as _;
-            const STACK_USER = bindings::PERF_SAMPLE_STACK_USER as _;
-            const WEIGHT = bindings::PERF_SAMPLE_WEIGHT as _;
-            const DATA_SRC = bindings::PERF_SAMPLE_DATA_SRC as _;
-            const IDENTIFIER = bindings::PERF_SAMPLE_IDENTIFIER as _;
-            const TRANSACTION = bindings::PERF_SAMPLE_TRANSACTION as _;
-            const REGS_INTR = bindings::PERF_SAMPLE_REGS_INTR as _;
-            const PHYS_ADDR = bindings::PERF_SAMPLE_PHYS_ADDR as _;
-            const AUX = bindings::PERF_SAMPLE_AUX as _;
-            const CGROUP = bindings::PERF_SAMPLE_CGROUP as _;
+impl ReadFormatExt for ReadFormat {
+    const MAX_NON_GROUP_SIZE: usize = Self::all() //
+        .difference(Self::GROUP)
+        .bits()
+        .count_ones() as usize
+        + 1;
 
-            // The following are present in perf_event.h but not yet documented
-            // in the manpage.
-            const DATA_PAGE_SIZE = bindings::PERF_SAMPLE_DATA_PAGE_SIZE as _;
-            const CODE_PAGE_SIZE = bindings::PERF_SAMPLE_CODE_PAGE_SIZE as _;
-            const WEIGHT_STRUCT = bindings::PERF_SAMPLE_WEIGHT_STRUCT as _;
-        }
-    }
+    // The format of a read from a group is like this
+    // struct read_format {
+    //     u64 nr;            /* The number of events */
+    //     u64 time_enabled;  /* if PERF_FORMAT_TOTAL_TIME_ENABLED */
+    //     u64 time_running;  /* if PERF_FORMAT_TOTAL_TIME_RUNNING */
+    //     struct {
+    //         u64 value;     /* The value of the event */
+    //         u64 id;        /* if PERF_FORMAT_ID */
+    //         u64 lost;      /* if PERF_FORMAT_LOST */
+    //     } values[nr];
+    // };
 
-    bitflags! {
-        /// Flags that control what data is returned when reading from a
-        /// perf_event file descriptor.
-        ///
-        /// See the [man page][0] for the authoritative documentation on what
-        /// these flags do.
-        ///
-        /// [0]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
-        #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
-        pub struct ReadFormat : u64 {
-            /// Emit the total amount of time the counter has spent enabled.
-            const TOTAL_TIME_ENABLED = bindings::PERF_FORMAT_TOTAL_TIME_ENABLED as _;
-
-            /// Emit the total amount of time the counter was actually on the
-            /// CPU.
-            const TOTAL_TIME_RUNNING = bindings::PERF_FORMAT_TOTAL_TIME_RUNNING as _;
-
-            /// Emit the counter ID.
-            const ID = bindings::PERF_FORMAT_ID as _;
-
-            /// If in a group, read all the counters in the group at once.
-            const GROUP = bindings::PERF_FORMAT_GROUP as _;
-
-            /// Emit the number of lost samples for this event.
-            const LOST = bindings::PERF_FORMAT_LOST as _;
-        }
-    }
-
-    impl ReadFormat {
-        pub(crate) const MAX_NON_GROUP_SIZE: usize = Self::all() //
-            .difference(Self::GROUP)
+    /// The size of the common prefix when reading a group.
+    fn prefix_len(&self) -> usize {
+        1 + (*self & (Self::TOTAL_TIME_ENABLED | Self::TOTAL_TIME_RUNNING))
             .bits()
             .count_ones() as usize
-            + 1;
+    }
 
-        // The format of a read from a group is like this
-        // struct read_format {
-        //     u64 nr;            /* The number of events */
-        //     u64 time_enabled;  /* if PERF_FORMAT_TOTAL_TIME_ENABLED */
-        //     u64 time_running;  /* if PERF_FORMAT_TOTAL_TIME_RUNNING */
-        //     struct {
-        //         u64 value;     /* The value of the event */
-        //         u64 id;        /* if PERF_FORMAT_ID */
-        //         u64 lost;      /* if PERF_FORMAT_LOST */
-        //     } values[nr];
-        // };
-
-        /// The size of the common prefix when reading a group.
-        pub(crate) fn prefix_len(&self) -> usize {
-            1 + (*self & (Self::TOTAL_TIME_ENABLED | Self::TOTAL_TIME_RUNNING))
-                .bits()
-                .count_ones() as usize
-        }
-
-        /// The size of each element when reading a group
-        pub(crate) fn element_len(&self) -> usize {
-            1 + (*self & (Self::ID | Self::LOST)).bits().count_ones() as usize
-        }
+    /// The size of each element when reading a group
+    fn element_len(&self) -> usize {
+        1 + (*self & (Self::ID | Self::LOST)).bits().count_ones() as usize
     }
 }
 

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -123,6 +123,17 @@ pub use crate::group::Group;
 pub use crate::group_data::{GroupData, GroupEntry, GroupIter};
 pub use crate::sampler::{Record, Sampler};
 
+/// Support for parsing data contained within [`Record`](crate::Record)s.
+///
+/// Note that this module is actually just the [`perf-event-data`][ped] crate.
+/// The documentation has been inlined here for convenience.
+///
+/// [ped]: ::perf_event_data
+///
+/// # perf-event-data
+#[doc(inline)]
+pub use perf_event_data as data;
+
 // ... separate public exports and non-public ones
 
 use std::convert::TryInto;

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -118,7 +118,9 @@ use perf_event_open_sys as sys;
 use hooks::sys;
 
 pub use crate::builder::{Builder, UnsupportedOptionsError};
-pub use crate::flags::{Clock, ReadFormat, SampleFlag, SampleSkid};
+#[doc(inline)]
+pub use crate::data::{ReadFormat, SampleFlags as SampleFlag};
+pub use crate::flags::{Clock, SampleSkid};
 pub use crate::group::Group;
 pub use crate::group_data::{GroupData, GroupEntry, GroupIter};
 pub use crate::sampler::{Record, Sampler};
@@ -143,6 +145,8 @@ use std::io;
 use std::os::fd::{AsRawFd, IntoRawFd, RawFd};
 use std::time::Duration;
 
+use crate::data::endian::Native;
+use crate::data::parse::ParseConfig;
 use crate::sys::bindings::PERF_IOC_FLAG_GROUP;
 use crate::sys::ioctls;
 
@@ -189,8 +193,8 @@ pub struct Counter {
     /// The unique id assigned to this counter by the kernel.
     id: u64,
 
-    /// The [`ReadFormat`] flags that were used to configure this `Counter`.
-    read_format: ReadFormat,
+    /// The parse config used by this counter.
+    config: ParseConfig<Native>,
 
     /// If we are a `Group`, then this is the count of how many members we have.
     member_count: u32,
@@ -198,11 +202,11 @@ pub struct Counter {
 
 impl Counter {
     /// Common initialization code shared between counters and groups.
-    pub(crate) fn new_internal(file: File, read_format: ReadFormat) -> std::io::Result<Self> {
+    pub(crate) fn new_internal(file: File, config: ParseConfig<Native>) -> std::io::Result<Self> {
         let mut counter = Self {
             file,
             id: 0,
-            read_format,
+            config,
             member_count: 1,
         };
 
@@ -503,15 +507,10 @@ impl Counter {
         }
 
         let group = self.do_read_group()?;
-        let data = group.get(self).unwrap();
+        let entry = group.get(self).unwrap();
+        let data = crate::data::ReadValue::from_group_and_entry(&group.data, &entry.0);
 
-        Ok(CounterData {
-            read_format: self.read_format.difference(ReadFormat::GROUP),
-            value: data.value(),
-            time_enabled: group.time_enabled().unwrap_or_default().as_nanos() as _,
-            time_running: group.time_running().unwrap_or_default().as_nanos() as _,
-            lost: data.lost().unwrap_or(0),
-        })
+        Ok(CounterData(data))
     }
 
     /// Read the values of all the counters in the current group.
@@ -556,24 +555,10 @@ impl Counter {
     /// ```
     pub fn read_group(&mut self) -> io::Result<GroupData> {
         if self.is_group() {
-            return self.do_read_group();
+            self.do_read_group()
+        } else {
+            Ok(GroupData::new(self.do_read_single()?.0.into()))
         }
-
-        let data = self.do_read_single()?;
-        let mut vec = Vec::with_capacity(ReadFormat::MAX_NON_GROUP_SIZE);
-        vec.push(data.count());
-
-        if let Some(time_enabled) = data.time_enabled() {
-            vec.push(time_enabled.as_nanos() as _);
-        }
-
-        if let Some(time_running) = data.time_running() {
-            vec.push(time_running.as_nanos() as _);
-        }
-
-        vec.push(self.id());
-
-        Ok(GroupData::new(vec, self.read_format | ReadFormat::GROUP))
     }
 
     /// Return this `Counter`'s current value and timesharing data.
@@ -651,18 +636,19 @@ impl Counter {
     }
 
     fn is_group(&self) -> bool {
-        self.read_format.contains(ReadFormat::GROUP)
+        self.config.read_format().contains(ReadFormat::GROUP)
     }
 
     /// Actual read implementation for when `ReadFormat::GROUP` is not set.
     fn do_read_single(&mut self) -> io::Result<CounterData> {
+        use crate::flags::ReadFormatExt;
         use std::io::Read;
         use std::mem::size_of;
 
-        debug_assert!(!self.read_format.contains(ReadFormat::GROUP));
+        debug_assert!(!self.is_group());
 
-        let mut data = [0u64; ReadFormat::MAX_NON_GROUP_SIZE];
-        let len = self.file.read(as_byte_slice_mut(&mut data))? / size_of::<u64>();
+        let mut data = [0u8; ReadFormat::MAX_NON_GROUP_SIZE * size_of::<u64>()];
+        let len = self.file.read(&mut data)?;
 
         if len == 0 {
             return Err(io::Error::new(
@@ -671,36 +657,18 @@ impl Counter {
             ));
         }
 
-        let mut iter = data.iter().take(len).skip(1).copied();
-        let mut read = |flag: ReadFormat| {
-            self.read_format
-                .contains(flag)
-                .then(|| iter.next())
-                .unwrap_or(Some(0))
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
-                        "read_format did not match the data returned by the kernel",
-                    )
-                })
-        };
+        let mut parser = crate::data::parse::Parser::new(&data[..len], self.config.clone());
+        let value: crate::data::ReadValue = parser
+            .parse()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-        let time_enabled = read(ReadFormat::TOTAL_TIME_ENABLED)?;
-        let time_running = read(ReadFormat::TOTAL_TIME_RUNNING)?;
-        let _id = read(ReadFormat::ID)?;
-        let lost = read(ReadFormat::LOST)?;
-
-        Ok(CounterData {
-            read_format: self.read_format,
-            value: data[0],
-            time_enabled,
-            time_running,
-            lost,
-        })
+        Ok(CounterData(value))
     }
 
     /// Actual read implementation for when `ReadFormat::GROUP` is set.
     fn do_read_group(&mut self) -> io::Result<GroupData> {
+        use crate::data::ReadGroup;
+        use crate::flags::ReadFormatExt;
         use std::io::Read;
         use std::mem::size_of;
 
@@ -717,11 +685,12 @@ impl Counter {
         //         u64 lost;      /* if PERF_FORMAT_LOST */
         //     } values[nr];
         // };
-        let prefix_len = self.read_format.prefix_len();
-        let element_len = self.read_format.element_len();
+        let read_format = self.config.read_format();
+        let prefix_len = read_format.prefix_len();
+        let element_len = read_format.element_len();
 
         let mut elements = (self.member_count as usize).max(1);
-        let mut data = vec![0; prefix_len + elements * element_len];
+        let mut data = vec![0u8; (prefix_len + elements * element_len) * size_of::<u64>()];
 
         // Backoff loop to try and get the correct size.
         //
@@ -732,11 +701,11 @@ impl Counter {
         // The next time around self.member_count will be set to the correct
         // count and we won't need to go through this loop multiple times.
         let len = loop {
-            match self.file.read(as_byte_slice_mut(&mut data)) {
-                Ok(len) => break len / size_of::<u64>(),
+            match self.file.read(&mut data) {
+                Ok(len) => break len,
                 Err(e) if e.raw_os_error() == Some(libc::ENOSPC) => {
                     elements *= 2;
-                    data.resize(prefix_len + elements * element_len, 0);
+                    data.resize((prefix_len + elements * element_len) * size_of::<u64>(), 0);
                 }
                 Err(e) => return Err(e),
             }
@@ -750,15 +719,16 @@ impl Counter {
         }
 
         data.truncate(len);
-        elements = data[0] as usize;
+        let mut parser = crate::data::parse::Parser::new(data.as_slice(), self.config.clone());
+        let data: ReadGroup = parser
+            .parse::<ReadGroup>()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+            .into_owned();
 
-        // The data returned is not in the format we expected.
-        if data.len() != prefix_len + elements * element_len {
-            return Err(io::Error::from_raw_os_error(libc::ENOSPC));
-        }
+        let data = GroupData::new(data);
 
-        let data = GroupData::new(data, self.read_format);
-        self.member_count = elements
+        self.member_count = data
+            .len()
             .try_into()
             .expect("group had more than u32::MAX elements");
 
@@ -800,15 +770,8 @@ impl fmt::Debug for Counter {
 }
 
 /// The data retrieved by reading from a [`Counter`].
-#[derive(Clone)]
-pub struct CounterData {
-    // If you update this struct remember to update the Debug impl as well.
-    read_format: ReadFormat,
-    value: u64,
-    time_enabled: u64,
-    time_running: u64,
-    lost: u64,
-}
+#[derive(Clone, Debug)]
+pub struct CounterData(crate::data::ReadValue);
 
 impl CounterData {
     /// The counter value.
@@ -816,7 +779,7 @@ impl CounterData {
     /// The meaning of this field depends on how the counter was configured when
     /// it was built; see ['Builder'].
     pub fn count(&self) -> u64 {
-        self.value
+        self.0.value()
     }
 
     /// How long this counter was enabled by the program.
@@ -824,10 +787,7 @@ impl CounterData {
     /// This will be present if [`ReadFormat::TOTAL_TIME_ENABLED`] was
     /// specified in `read_format` when the counter was built.
     pub fn time_enabled(&self) -> Option<Duration> {
-        self.read_format
-            .contains(ReadFormat::TOTAL_TIME_ENABLED)
-            .then_some(self.time_enabled)
-            .map(Duration::from_nanos)
+        self.0.time_enabled().map(Duration::from_nanos)
     }
 
     /// How long the kernel actually ran this counter.
@@ -840,10 +800,7 @@ impl CounterData {
     /// This will be present if [`ReadFormat::TOTAL_TIME_RUNNING`] was
     /// specified in `read_format` when the counter was built.
     pub fn time_running(&self) -> Option<Duration> {
-        self.read_format
-            .contains(ReadFormat::TOTAL_TIME_RUNNING)
-            .then_some(self.time_running)
-            .map(Duration::from_nanos)
+        self.0.time_running().map(Duration::from_nanos)
     }
 
     /// The number of lost samples of this event.
@@ -851,31 +808,7 @@ impl CounterData {
     /// This will be present if [`ReadFormat::LOST`] was specified in
     /// `read_format` when the counter was built.
     pub fn lost(&self) -> Option<u64> {
-        self.read_format
-            .contains(ReadFormat::LOST)
-            .then_some(self.lost)
-    }
-}
-
-impl fmt::Debug for CounterData {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut dbg = f.debug_struct("CounterData");
-
-        dbg.field("count", &self.count());
-
-        if let Some(time_enabled) = self.time_enabled() {
-            dbg.field("time_enabled", &time_enabled);
-        }
-
-        if let Some(time_running) = self.time_running() {
-            dbg.field("time_running", &time_running);
-        }
-
-        if let Some(lost) = self.lost() {
-            dbg.field("lost", &lost);
-        }
-
-        dbg.finish_non_exhaustive()
+        self.0.lost()
     }
 }
 
@@ -907,17 +840,6 @@ pub struct CountAndTime {
     /// shared the underlying hardware with others, and you should prorate its
     /// value accordingly.
     pub time_running: u64,
-}
-
-/// View a slice of u64s as a byte slice.
-fn as_byte_slice_mut(slice: &mut [u64]) -> &mut [u8] {
-    unsafe {
-        let (head, slice, tail) = slice.align_to_mut();
-        debug_assert!(head.is_empty());
-        debug_assert!(tail.is_empty());
-
-        slice
-    }
 }
 
 /// Produce an `io::Result` from an errno-style system call.

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -125,12 +125,14 @@ pub use crate::group::Group;
 pub use crate::group_data::{GroupData, GroupEntry, GroupIter};
 pub use crate::sampler::{Record, Sampler};
 
-/// Support for parsing data contained within [`Record`](crate::Record)s.
+/// Support for parsing data contained within `Record`s.
 ///
 /// Note that this module is actually just the [`perf-event-data`][ped] crate.
 /// The documentation has been inlined here for convenience.
 ///
-/// [ped]: ::perf_event_data
+// TODO: Directly linking to the crate causes an ICE in rustdoc. It is fixed in
+//       nightly but not in the latest stable.
+/// [ped]: http://docs.rs/perf-event-data
 ///
 /// # perf-event-data
 #[doc(inline)]

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -224,6 +224,11 @@ impl Counter {
         self.id
     }
 
+    /// The [`ParseConfig`] for this `Counter`.
+    pub fn config(&self) -> &ParseConfig<Native> {
+        &self.config
+    }
+
     /// Allow this `Counter` to begin counting its designated event.
     ///
     /// This does not affect whatever value the `Counter` had previously; new

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -129,9 +129,9 @@ pub use crate::sampler::{Record, Sampler};
 ///
 /// Note that this module is actually just the [`perf-event-data`][ped] crate.
 /// The documentation has been inlined here for convenience.
-///
 // TODO: Directly linking to the crate causes an ICE in rustdoc. It is fixed in
 //       nightly but not in the latest stable.
+///
 /// [ped]: http://docs.rs/perf-event-data
 ///
 /// # perf-event-data

--- a/perf-event/src/sampler.rs
+++ b/perf-event/src/sampler.rs
@@ -271,7 +271,7 @@ impl<'s> Record<'s> {
 
     /// Access the `misc` field of the kernel record header.
     ///
-    /// This contains a set of flags carry some additional metadata on the
+    /// This contains a set of flags that carry some additional metadata on the
     /// record being emitted by the kernel.
     pub fn misc(&self) -> u16 {
         self.header.misc

--- a/perf-event/src/sampler.rs
+++ b/perf-event/src/sampler.rs
@@ -449,7 +449,7 @@ unsafe impl<'a> ParseBuf<'a> for ByteBuffer<'a> {
             Self::Split([a, b]) => {
                 count -= a.len();
                 b.advance(count);
-                *self = Self::Single(*b);
+                *self = Self::Single(b);
             }
         }
     }


### PR DESCRIPTION
As in the title, this PR uses the `perf_event_data` crate to add support for parsing `Record`s gotten from a sampler. I've also replaced the implementation details of the various counter read related structs with types from `perf_event_data`.

The detailed changes here are
- `perf_event_data` is now reexported as the `data` module in the crate root. I have used `#[doc(inline)]` so that the docs are inlined into the main crate.
- The internals of `GroupData`, `GroupEntry`, `GroupIter`, and `CounterData` have all been replaced with types from `perf_event_data`. No public API changes have been made here.
- `Counter` now keeps a `ParseConfig` from `perf_event_data` internally instead of just a `ReadFormat` value. This can now be accessed via `Counter::config`. This increases the size of `Counter` by 16 bytes but I don't think that that is an issue.