### PR TITLE
Add a changelog to perf-event2

### DIFF
--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.0] - 2023-04-20
+### Added
+- Add `Sampler` - a `Counter` which also reads sample events emitted by the kernel.
+- Group leaders can now be a `Group`, `Counter`, or `Sampler`.
+- Add `Builder::build_group` to build a group with a non-default config.
+- Add all missing config options for `Builder`.
+
+### Changed
+- The `Event` enum has been replaced with an `Event` trait.
+- Constructing a `Builder` now requires that you specify an event type up front
+  instead of having a default of `Hardware::INSTRUCTIONS`.

--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Expose the `perf_event_data` crate as the `data` module.
 - Add `Record::parse_record` to parse records to `data::Record`.
+- Add `Software::CGROUP_SWITCHES` and `Software::BPF_OUTPUT` events (#9). @Phantomical
 
 ## [0.5.0] - 2023-04-20
 ### Added

--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Expose the `perf_event_data` crate as the `data` module.
+- Add `Record::parse_record` to parse records to `data::Record`.
 
 ## [0.5.0] - 2023-04-20
 ### Added


### PR DESCRIPTION
The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). I haven't bothered adding entries for releases for versions before v0.5.0 since there wasn't a changelog originally.