### PR TITLE
Rename `WhichCache` to `CacheId`

### DIFF
--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `Hardware` is no longer a rust enum. The constants remain the same.
 - `Software` is no longer a rust enum. The constants remain the same.
-- The same applies for `WhichCache`, `CacheOp`, and `CacheResult`
+- The same applies for `WhichCache`, `CacheOp`, and `CacheResult`.
+- `WhichCache` has been renamed to `CacheId`.
 
 ## [0.5.0] - 2023-04-20
 ### Added

--- a/perf-event/examples/big-group.rs
+++ b/perf-event/examples/big-group.rs
@@ -1,4 +1,4 @@
-use perf_event::events::{Cache, CacheOp, CacheResult, Hardware, CacheId};
+use perf_event::events::{Cache, CacheId, CacheOp, CacheResult, Hardware};
 use perf_event::{Builder, Group};
 
 fn main() -> std::io::Result<()> {

--- a/perf-event/examples/big-group.rs
+++ b/perf-event/examples/big-group.rs
@@ -1,9 +1,9 @@
-use perf_event::events::{Cache, CacheOp, CacheResult, Hardware, WhichCache};
+use perf_event::events::{Cache, CacheOp, CacheResult, Hardware, CacheId};
 use perf_event::{Builder, Group};
 
 fn main() -> std::io::Result<()> {
     const ACCESS: Cache = Cache {
-        which: WhichCache::L1D,
+        which: CacheId::L1D,
         operation: CacheOp::READ,
         result: CacheResult::ACCESS,
     };

--- a/perf-event/examples/group.rs
+++ b/perf-event/examples/group.rs
@@ -1,4 +1,4 @@
-use perf_event::events::{Cache, CacheOp, CacheResult, Hardware, CacheId};
+use perf_event::events::{Cache, CacheId, CacheOp, CacheResult, Hardware};
 use perf_event::{Builder, Group};
 
 fn main() -> std::io::Result<()> {

--- a/perf-event/examples/group.rs
+++ b/perf-event/examples/group.rs
@@ -1,9 +1,9 @@
-use perf_event::events::{Cache, CacheOp, CacheResult, Hardware, WhichCache};
+use perf_event::events::{Cache, CacheOp, CacheResult, Hardware, CacheId};
 use perf_event::{Builder, Group};
 
 fn main() -> std::io::Result<()> {
     const ACCESS: Cache = Cache {
-        which: WhichCache::L1D,
+        which: CacheId::L1D,
         operation: CacheOp::READ,
         result: CacheResult::ACCESS,
     };

--- a/perf-event/src/events.rs
+++ b/perf-event/src/events.rs
@@ -208,7 +208,7 @@ impl Event for Software {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cache {
     /// Which cache is being monitored? (data, instruction, ...)
-    pub which: WhichCache,
+    pub which: CacheId,
 
     /// What operation is being monitored? (read, write, etc.)
     pub operation: CacheOp,
@@ -230,6 +230,10 @@ impl Event for Cache {
     }
 }
 
+#[doc(hidden)]
+#[deprecated = "WhichCache has been renamed to CacheId"]
+pub type WhichCache = CacheId;
+
 c_enum! {
     /// A cache whose events we would like to count.
     ///
@@ -241,7 +245,7 @@ c_enum! {
     /// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
     #[repr(transparent)]
     #[derive(Clone, Copy, Eq, PartialEq, Hash)]
-    pub enum WhichCache : u8 {
+    pub enum CacheId : u8 {
         /// Level 1 data cache.
         L1D = bindings::PERF_COUNT_HW_CACHE_L1D as _,
 


### PR DESCRIPTION
Code using `WhichCache` will continue to work, although it is `#[doc(hidden)]` and deprecated so it will get a warning.