### PR TITLE
Silence `clippy::assign_op_pattern` lint

### DIFF
--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -76,6 +76,8 @@
 //! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
 
 #![deny(missing_docs)]
+// Bitflags 
+#![allow(clippy::assign_op_pattern)]
 
 /// A helper macro for silencing warnings when a type is only implemented so
 /// that it can be linked in the docs.

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -76,7 +76,7 @@
 //! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
 
 #![deny(missing_docs)]
-// Bitflags 
+// The bitflags macro is generating this lint internally.
 #![allow(clippy::assign_op_pattern)]
 
 /// A helper macro for silencing warnings when a type is only implemented so


### PR DESCRIPTION
This is getting triggered by code within the `bitflags!` macro. There's nothing we can do about it so it is better to just silence it instead.