### PR TITLE
Prepare for v0.6.0 release

### DIFF
--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0] - 2023-05-17
 ### Added
 - Expose the `perf_event_data` crate as the `data` module.
 - Add `Record::parse_record` to parse records to `data::Record`.

--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event2"
-version = "0.5.1"
+version = "0.6.0"
 description = "A Rust interface to Linux performance monitoring"
 license = "MIT OR Apache-2.0"
 authors = ["Sean Lynch <sean@lynches.ca>", "Jim Blandy <jimb@red-bean.com>"]


### PR DESCRIPTION
## [0.6.0] - 2023-05-17
### Added
- Expose the `perf_event_data` crate as the `data` module.
- Add `Record::parse_record` to parse records to `data::Record`.
- Add `Software::CGROUP_SWITCHES` and `Software::BPF_OUTPUT` events (#9). @Phantomical

### Changed
- `Hardware` is no longer a rust enum. The constants remain the same.
- `Software` is no longer a rust enum. The constants remain the same.
- The same applies for `WhichCache`, `CacheOp`, and `CacheResult`.
- `WhichCache` has been renamed to `CacheId`.