### PR TITLE
Prepare sys-v5.0.3 release

### DIFF
--- a/perf-event-open-sys/Cargo.toml
+++ b/perf-event-open-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event-open-sys2"
-version = "5.0.2"
+version = "5.0.3"
 description = """
 Unsafe, direct bindings for Linux's perf_event_open system call, with associated
 types and constants.

--- a/perf-event-open-sys/RELEASE-NOTES.md
+++ b/perf-event-open-sys/RELEASE-NOTES.md
@@ -1,6 +1,8 @@
 # Release notes for `perf-event-open-sys`
 
 ## Unreleased
+
+## 5.0.3
 - Regenerated the bindings from the linux 6.3.4 source tree.
 
 ## 5.0.2


### PR DESCRIPTION
## 5.0.3
- Regenerated the bindings from the linux 6.3.4 source tree.
