### PR TITLE
Only warn on missing docs in debug, deny in release

### DIFF
--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -77,7 +77,6 @@
 
 #![cfg_attr(debug_assertions, warn(missing_docs))]
 #![cfg_attr(not(debug_assertions), deny(missing_docs))]
-
 // The bitflags macro is generating this lint internally.
 #![allow(clippy::assign_op_pattern)]
 

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -75,7 +75,9 @@
 //!
 //! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
 
-#![deny(missing_docs)]
+#![cfg_attr(debug_assertions, warn(missing_docs))]
+#![cfg_attr(not(debug_assertions), deny(missing_docs))]
+
 // The bitflags macro is generating this lint internally.
 #![allow(clippy::assign_op_pattern)]
 


### PR DESCRIPTION
Always getting errors while developing is inconvenient. Better to leave it as a warning in dev mode while still keeping it as an error in release mode.