### PR TITLE
Prepare for perf-event2 0.6.1 release

### DIFF
--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.1] - 2023-05-19
 ### Added
 - Expose the `IOC_SET_BPF` ioctl as `Counter::set_bpf`.
 - Add `Event::update_attrs_with_data` to allow events to store references to

--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -8,10 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Expose the `IOC_SET_BPF` ioctl as `Counter::set_bpf`.
-- Add `KProbe` and `UProbe` events.
 - Add `Event::update_attrs_with_data` to allow events to store references to
   owned data within `Builder`'s `perf_event_attr` struct.
-- Add `Tracepoint` event type.
+- Add `KProbe`, `UProbe`, and `Tracepoint` event types.
 
 ## [0.6.0] - 2023-05-17
 ### Added

--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event2"
-version = "0.6.0"
+version = "0.6.1"
 description = "A Rust interface to Linux performance monitoring"
 license = "MIT OR Apache-2.0"
 authors = ["Sean Lynch <sean@lynches.ca>", "Jim Blandy <jimb@red-bean.com>"]
@@ -21,7 +21,6 @@ name = "perf_event"
 [features]
 # Enable syscall interception hooks for mock testing and logging.
 hooks = []
-default = []
 
 [dependencies]
 bitflags = "2.1"


### PR DESCRIPTION
## [0.6.1] - 2023-05-19
### Added
- Expose the `IOC_SET_BPF` ioctl as `Counter::set_bpf`.
- Add `Event::update_attrs_with_data` to allow events to store references to
  owned data within `Builder`'s `perf_event_attr` struct.
- Add `KProbe`, `UProbe`, and `Tracepoint` event types.