### PR TITLE
Add rustfmt option to automatically group imports and reformat

### DIFF
--- a/perf-event/rustfmt.toml
+++ b/perf-event/rustfmt.toml
@@ -2,3 +2,5 @@
 format_code_in_doc_comments = true
 format_macro_bodies = true
 wrap_comments = true
+
+imports_granularity = "Module"

--- a/perf-event/src/events/util.rs
+++ b/perf-event/src/events/util.rs
@@ -1,8 +1,7 @@
-use std::fmt;
-use std::io;
 use std::num::ParseIntError;
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::{fmt, io};
 
 /// Helper to read and cache the type of a dynamic perf PMU event.
 ///

--- a/perf-event/src/flags.rs
+++ b/perf-event/src/flags.rs
@@ -1,5 +1,4 @@
-use crate::Builder;
-use crate::ReadFormat;
+use crate::{Builder, ReadFormat};
 
 used_in_docs!(Builder);
 

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -144,11 +144,10 @@ pub use perf_event_data as data;
 // ... separate public exports and non-public ones
 
 use std::convert::TryInto;
-use std::fmt;
 use std::fs::File;
-use std::io;
 use std::os::fd::{AsRawFd, IntoRawFd, RawFd};
 use std::time::Duration;
+use std::{fmt, io};
 
 use crate::data::endian::Native;
 use crate::data::parse::ParseConfig;


### PR DESCRIPTION
It is not reasonable to expect people making PRs to manually do this. Better to have it enforced via rustfmt.