### PR TITLE
Update the link to perf-event within the perf-event-open-sys2 readme

### DIFF
--- a/perf-event-open-sys/README.md
+++ b/perf-event-open-sys/README.md
@@ -18,9 +18,9 @@ This crate provides:
 All functions are direct, `unsafe` wrappers for the underlying calls. They
 operate on raw pointers and raw file descriptors.
 
-For a type-safe API for basic functionality, see the [perf-event] crate.
+For a type-safe API for basic functionality, see the [perf-event2] crate.
 
-[perf-event]: https://crates.io/crates/perf-event
+[perf-event2]: https://crates.io/crates/perf-event2
 
 ### Using perf types on other platforms
 


### PR DESCRIPTION
It should be pointing people to the perf-event2 crate instead of perf-event.