### PR TITLE
Improve the documentation for the `x86::Msr` event.

### DIFF
--- a/perf-event/src/events/mod.rs
+++ b/perf-event/src/events/mod.rs
@@ -14,9 +14,6 @@
 //! - [`Software`] events are counted by the kernel. This includes things like
 //!   context switches, page faults, and so on.
 //!
-//! - [`Msr`] events are counted by the processor MSRs including timestmap
-//!   counter, aperf, mperf MSRs.
-//!
 //! - [`Breakpoint`] events correspond to hardware breakpoints. They can count
 //!   read/write accesses to an address as well as execution of an instruction
 //!   address.
@@ -26,11 +23,6 @@
 //! are dynamically registered by drivers and kernel modules. If something you
 //! want is missing, think about the best API to expose it, and submit a pull
 //! request!
-//!
-//! [`Hardware`]: enum.Hardware.html
-//! [`Software`]: enum.Software.html
-//! [`Cache`]: struct.Cache.html
-//! [`Msr`]: struct.Msr.html
 
 use std::sync::Arc;
 

--- a/perf-event/src/events/x86/msr.rs
+++ b/perf-event/src/events/x86/msr.rs
@@ -62,7 +62,7 @@ c_enum! {
         MPERF = 0x2,
 
         /// Productive Performance Counter (`MSR_PPERF`).
-        /// 
+        ///
         /// This counter is similar to `APERF` but only counts cycles perceived
         /// by the hardware as contributing to instruction execution (i.e. not
         /// halted and not stalled). This counter increments at teh same rate
@@ -73,36 +73,36 @@ c_enum! {
         PPERF = 0x3,
 
         /// System Management Interrupt Counter (`MSR_SMI_COUNT`).
-        /// 
+        ///
         /// This counter counts the number of System Management Interrupts.
-        /// 
+        ///
         /// Only available on Intel CPUs.
         SMI = 0x4,
 
         /// Performance Timestamp Counter (`MSR_F15H_PTSC`).
-        /// 
+        ///
         /// This is a free-running counter that increments at a constant rate
         /// of 100MHz and is synchronized across all cores in a node to within
         /// +/-1.
-        /// 
+        ///
         /// This counter is only available on AMD CPUs.
         PTSC = 0x5,
 
         /// Instructions Retired Performance Counter (`MSR_F17H_IRPERF`)
-        /// 
+        ///
         /// This is a dedicated counter that always counts the number of
         /// instructions retired.
-        /// 
+        ///
         /// This counter is only available on AMD CPUs.
         IRPERF = 0x6,
 
         /// Thermal Monitor Status (MSR_IA32_THERM_STATUS).
-        /// 
+        ///
         /// This MSR provides status information about the thermal status of
         /// the current CPU core. It contains quite a bit of info so see the
         /// Intel SDM, Volume 3, section 15.8.2.5, for documentation on what
         /// it contains.
-        /// 
+        ///
         /// This counter is only available on Intel CPUs.
         THERM = 0x7,
     }

--- a/perf-event/src/events/x86/msr.rs
+++ b/perf-event/src/events/x86/msr.rs
@@ -4,63 +4,148 @@ use c_enum::c_enum;
 use perf_event_open_sys::bindings;
 
 use crate::events::{CachedPmuType, Event};
+use crate::Builder;
+
+used_in_docs!(Builder);
 
 static MSR_TYPE: CachedPmuType = CachedPmuType::new("msr");
 
 c_enum! {
-    /// The [MSRs] supported by the [Linux msr pmu]
+    /// Model-specific registers (MSRs) supported by the Linux msr PMU.
     ///
-    /// [Linux msr pmu]: https://github.com/torvalds/linux/blob/master/arch/x86/events/msr.c
-    /// [MSRs]: https://github.com/torvalds/linux/blob/master/arch/x86/include/asm/msr-index.h
+    /// Only some of these will be supported by any given system. To see which
+    /// are supported on the current system you can look in the
+    /// `/sys/bus/event_source/devices/msr/events` folder.
+    ///
+    /// The full list of MSR IDs supported by the msr PMU can be found within
+    /// the [kernel source][src]. This enum aims to cover all entries supported
+    /// by the kernel but may of course not be completedly up to date.
+    ///
+    /// Documentation on the underlying MSRs can be found in either the [intel
+    /// software development manual][intel] or the [AMD architecture
+    /// programmer's manual][amd].
+    ///
+    /// [src]: https://github.com/torvalds/linux/blob/master/arch/x86/events/msr.c
+    /// [intel]: https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html
+    /// [amd]: https://www.amd.com/system/files/TechDocs/40332.pdf
     #[derive(Clone, Copy, Eq, PartialEq, Hash)]
     pub enum MsrId: u64 {
-        /// x86 Time Stamp Counter (MSR_IA32_TSC).
+        /// x86 Time Stamp Counter.
+        ///
+        /// This is the counter read by the `rdtsc` instruction. It is defined
+        /// on all x86 CPUs.
         TSC = 0x0,
-        /// x86 Actual Performance Frequency Clock (MSR_IA32_APERF).
+
+        /// x86 Actual Performance Frequency Clock (`MSR_IA32_APERF`).
+        ///
+        /// This counter increments in proportion to the actual CPU performance.
+        /// Note that only the ratio between the `APERF` and `MPERF` counters
+        /// has an architecturally defined meaning, not their absolute values.
+        ///
+        /// This counter is only available on Intel CPUs.
         APERF = 0x1,
-        /// x86 Maximum Performance Frequency Clock Count (MSR_IA32_MPERF)
+
+        /// x86 Maximum Performance Frequency Clock Count (`MSR_IA32_MPERF`)
         ///
+        /// This counter increments at a fixed frequency irrespective of CPU
+        /// power state or frequency transitions. Note that only the ratio
+        /// between the `APERF` and `MPERF` counters has an architecturally
+        /// defined meaning, not their absolute values.
+        ///
+        /// You can use `APERF` and `MPERF` together to calculate the the
+        /// average frequency of the CPU over the measurement period like so:
+        /// ```text
         /// (APERF / MPERF) * CPU base frequency = running CPU frequency
-        MPERF = 0x2,
-        /// Intel The Productive Performance MSR (MSR_PPERF).
+        /// ```
         ///
-        /// PPERF is similar to APERF but only increased for non-halted cycles.
+        /// This counter is only available on Intel CPUs.
+        MPERF = 0x2,
+
+        /// Productive Performance Counter (`MSR_PPERF`).
+        /// 
+        /// This counter is similar to `APERF` but only counts cycles perceived
+        /// by the hardware as contributing to instruction execution (i.e. not
+        /// halted and not stalled). This counter increments at teh same rate
+        /// as `APERF` and the ratio `PPERF / APERF` can be used as an
+        /// indicator of workload scalability.
+        ///
+        /// This counter is only available on Intel CPUs.
         PPERF = 0x3,
-        /// Intel System Management Interrupt Counter (MSR_SMI_COUNT).
+
+        /// System Management Interrupt Counter (`MSR_SMI_COUNT`).
+        /// 
+        /// This counter counts the number of System Management Interrupts.
+        /// 
+        /// Only available on Intel CPUs.
         SMI = 0x4,
-        /// AMD Performance Timestamp Counter (MSR_F15H_PTSC).
+
+        /// Performance Timestamp Counter (`MSR_F15H_PTSC`).
+        /// 
+        /// This is a free-running counter that increments at a constant rate
+        /// of 100MHz and is synchronized across all cores in a node to within
+        /// +/-1.
+        /// 
+        /// This counter is only available on AMD CPUs.
         PTSC = 0x5,
-        /// AMD Instructions Retired Performance Counter (MSR_F17H_IRPERF)
+
+        /// Instructions Retired Performance Counter (`MSR_F17H_IRPERF`)
+        /// 
+        /// This is a dedicated counter that always counts the number of
+        /// instructions retired.
+        /// 
+        /// This counter is only available on AMD CPUs.
         IRPERF = 0x6,
-        /// Intel Thermal Status MSR (MSR_IA32_THERM_STATUS).
+
+        /// Thermal Monitor Status (MSR_IA32_THERM_STATUS).
+        /// 
+        /// This MSR provides status information about the thermal status of
+        /// the current CPU core. It contains quite a bit of info so see the
+        /// Intel SDM, Volume 3, section 15.8.2.5, for documentation on what
+        /// it contains.
+        /// 
+        /// This counter is only available on Intel CPUs.
         THERM = 0x7,
     }
 }
 
-/// The MSR event allowing you to use the MSRs defined in the [Linux msr pmu].
+/// A perf event providing access to a subset of the model-specific registers
+/// (MSRs) on x86 CPUs.
 ///
-/// [Linux msr pmu]: https://github.com/torvalds/linux/blob/master/arch/x86/events/msr.c
+/// The exact MSRs that are available on any given system depend on the system
+/// CPU. The kernel exposes the available event types for the current
+/// system under `/sys/bus/event_source/devices/msr/events`. You can use the
+/// files in that folder to check if an MSR event is supported. Alternatively,
+/// you can just try and build the counter, either will work.
+///
+/// The full list of MSR IDs that are supported can be seen [in the linux
+/// source][0]. [`MsrId`] aims to be comprehensive but may not be up to date.
+///
+/// # Note
+/// MSR events do not support filtering based on user-space vs kernel-space. You
+/// will need to set [`exclude_kernel(false)`][exk] and
+/// [`exclude_hv(false)`][exhv] or else you will get errors when calling
+/// [`Builder::build`].
+///
+/// [0]: https://github.com/torvalds/linux/blob/master/arch/x86/events/msr.c
+/// [exk]: crate::Builder::exclude_kernel
+/// [exhv]: crate::Builder::exclude_hv
+#[derive(Copy, Clone, Debug)]
 pub struct Msr {
     ty: u32,
-    config: MsrId,
+    id: MsrId,
 }
 
 impl Msr {
     /// Create a MSR event.
     ///
-    /// Please notice that because MSR events don't support user-only counting,
-    /// please clear the kernel and hv exclusive bits by calling
-    /// [exclude_kernel](crate::Builder::exclude_hv)(`false`) and
-    /// [exclude_kernel](crate::Builder::exclude_kernel)(`false`).
-    ///
     /// # Errors
-    /// This will attempt to read the PMU type from
-    /// `/sys/bus/event_source`. It will return an error if the MSR PMU is
-    /// missing.
-    pub fn new(config: MsrId) -> io::Result<Self> {
+    /// This will attempt to read the PMU type from kernel device filesystem.
+    /// Any errors due to missing files or folders will result in an error here.
+    /// (e.g. should the kernel not have an MSR perf-event device).
+    pub fn new(id: MsrId) -> io::Result<Self> {
         Ok(Self {
             ty: MSR_TYPE.get()?,
-            config,
+            id,
         })
     }
 }
@@ -68,6 +153,6 @@ impl Msr {
 impl Event for Msr {
     fn update_attrs(self, attr: &mut bindings::perf_event_attr) {
         attr.type_ = self.ty;
-        attr.config = self.config.into();
+        attr.config = self.id.into();
     }
 }


### PR DESCRIPTION
This expands the documentation on the `Msr` and `MsrId` types to be much more comprehensive.