### PR TITLE
Make `Sampler::next` record take `&mut self` instead of `&self`

### DIFF
--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Sampler::read_user` method to for reading counters from userspace.
   Only x86 and x86_64 are supported when reading counters. 
 
+## Changed
+- **(breaking)** `Sampler::next_record` now takes `&mut self` instead of `&self`.
+  This fixes UB that could arise due to having multiple `Record`s from the same
+  `Sampler` existing at the same time.
+
 ## [0.6.3] - 2023-05-30
 ### Added
 - Introduce a new `Dynamic` event type along with its builder. These allow

--- a/perf-event/src/sampler.rs
+++ b/perf-event/src/sampler.rs
@@ -91,7 +91,7 @@ impl Sampler {
     ///
     /// [`next_blocking`]: Self::next_blocking
     /// [man]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
-    pub fn next_record(&self) -> Option<Record> {
+    pub fn next_record(&mut self) -> Option<Record> {
         use std::{mem, ptr, slice};
 
         let page = self.page();


### PR DESCRIPTION
This seems to have been forgotten in the initial implementation. Having multiple instances of `Record` hanging around from the sample `Sampler` could potentially cause UB and will almost 1definitely permanently corrupt the ring buffer state. Unfortunately, the fix is a breaking change but it's better to do it now rather than have the issue remain.