### PR TITLE
Fix a panic within `ByteBuffer::truncate`

### DIFF
--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed a panic in `Sampler` when handling a record that wrapped around the end
+  of the sampler ring buffer.
 
 ## [0.7.1] - 2023-10-05
 ### Added

--- a/perf-event/src/sampler.rs
+++ b/perf-event/src/sampler.rs
@@ -667,7 +667,7 @@ impl<'a> ByteBuffer<'a> {
         *self = match *self {
             Self::Single(buf) => Self::Single(&buf[..new_len]),
             Self::Split([a, b]) => {
-                if a.len() <= new_len {
+                if new_len <= a.len() {
                     Self::Single(&a[..new_len])
                 } else {
                     Self::Split([a, &b[..new_len - a.len()]])
@@ -867,5 +867,29 @@ mod tests {
 
         assert_eq!(&out, b"aaaaa");
         assert_eq!(buf.len(), 6);
+    }
+
+    #[test]
+    fn buf_truncate_over_split() {
+        let mut out = [0u8; 11];
+        let mut buf = ByteBuffer::Split([b"1234567890", b"abc"]);
+
+        buf.truncate(11);
+        assert_eq!(buf.len(), 11);
+
+        buf.copy_to_slice(&mut out);
+        assert_eq!(&out, b"1234567890a");
+    }
+
+    #[test]
+    fn buf_truncate_before_split() {
+        let mut out = [0u8; 5];
+        let mut buf = ByteBuffer::Split([b"1234567890", b"abc"]);
+
+        buf.truncate(5);
+        assert_eq!(buf.len(), 5);
+
+        buf.copy_to_slice(&mut out);
+        assert_eq!(&out, b"12345");
     }
 }


### PR DESCRIPTION
There was a reversed comparison when determining whether we should advance past the split within the buffer. It was checking whether `a.len() <= new_len` but it should have been checking whether `new_len <= a.len()`. This was leading to panics whenever a sampler record ended up being split.

I've fixed the if statement and added some test cases to cover both split cases with a truncate.