### PR TITLE
Prepare for v0.7.2 release

### DIFF
--- a/perf-event/CHANGELOG.md
+++ b/perf-event/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.2] - 2023-10-22
 ### Fixed
 - Fixed a panic in `Sampler` when handling a record that wrapped around the end
   of the sampler ring buffer.

--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event2"
-version = "0.7.1"
+version = "0.7.2"
 description = "A Rust interface to Linux performance monitoring"
 license = "MIT OR Apache-2.0"
 authors = ["Sean Lynch <sean@lynches.ca>", "Jim Blandy <jimb@red-bean.com>"]


### PR DESCRIPTION
## [0.7.2] - 2023-10-22
### Fixed
- Fixed a panic in `Sampler` when handling a record that wrapped around the end of the sampler ring buffer.