### PR TITLE
Update the c_enum crate to v0.2

### DIFF
--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -24,7 +24,7 @@ hooks = []
 
 [dependencies]
 bitflags = "2.1"
-c-enum = "0.1"
+c-enum = "0.2.0"
 libc = "0.2"
 memmap2 = "0.9"
 perf-event-data = "0.1.1"

--- a/perf-event/src/events/cache.rs
+++ b/perf-event/src/events/cache.rs
@@ -105,7 +105,9 @@ c_enum! {
         /// Memory accesses that stay local to the originating NUMA node.
         NODE = bindings::PERF_COUNT_HW_CACHE_NODE as _,
     }
+}
 
+c_enum! {
     /// What sort of cache operation we would like to observe.
     ///
     /// This is used in the `Cache` type as part of the identification of a cache
@@ -126,7 +128,9 @@ c_enum! {
         /// Prefetch accesses.
         PREFETCH = bindings::PERF_COUNT_HW_CACHE_OP_PREFETCH as _,
     }
+}
 
+c_enum! {
     /// What sort of cache result we're interested in observing.
     ///
     /// `ACCESS` counts the total number of operations performed on the cache,


### PR DESCRIPTION
Since `c_enum` v0.2 no longer supports declaring multiple enums in a single c_enum! block I have also gone and split up the blocks where applicable.