### PR TITLE
Fix a conditional in the dynamic_msr_event test

### DIFF
--- a/perf-event/src/events/dynamic.rs
+++ b/perf-event/src/events/dynamic.rs
@@ -702,7 +702,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86_64", target_arch = "i686"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     fn dynamic_msr_event() {
         if !pmu_enabled("msr") {
             return;


### PR DESCRIPTION
Turns out the correct `target_arch` condition here is `x86` instead of `i686`.