### PR TITLE
Add builder convenience method to Group

### DIFF
--- a/perf-event/src/group.rs
+++ b/perf-event/src/group.rs
@@ -99,14 +99,7 @@ impl Group {
     /// on any CPU. If you need to build a `Group` with different settings you
     /// will need to use [`Builder::build_group`].
     pub fn new() -> io::Result<Group> {
-        Builder::new(Software::DUMMY)
-            .read_format(
-                ReadFormat::GROUP
-                    | ReadFormat::TOTAL_TIME_ENABLED
-                    | ReadFormat::TOTAL_TIME_RUNNING
-                    | ReadFormat::ID,
-            )
-            .build_group()
+        Self::builder().build_group()
     }
 
     /// Construct a [Builder] preconfigured for creating a `Group`.

--- a/perf-event/src/group.rs
+++ b/perf-event/src/group.rs
@@ -109,7 +109,23 @@ impl Group {
             .build_group()
     }
 
-    /// Conveniently create a [Builder] preconfigured for groups.
+    /// Construct a [Builder] preconfigured for creating a `Group`.
+    ///
+    /// Specifically, this creates a builder with the [`Software::DUMMY`] event
+    /// and with [`read_format`] set to `GROUP | ID | TOTAL_TIME_ENABLED |
+    /// TOTAL_TIME_RUNNING`. If you override [`read_format`] you will need to
+    /// ensure that [`ReadFormat::GROUP`] is set, otherwise [`build_group`] will
+    /// return an error.
+    ///
+    /// Note that any counter added to this group must observe the same set of
+    /// CPUs and processes as the group itself. That means if you configure the
+    /// group to observe a single CPU then the members of the group must also be
+    /// configured to only observe a single CPU, the same applies when choosing
+    /// target processes. Failing to follow this will result in an error when
+    /// adding the counter to the group.
+    ///
+    /// [`read_format`]: Builder::read_format
+    /// [`build_group`]: Builder::build_group
     pub fn builder() -> Builder<'static> {
         let mut builder = Builder::new(Software::DUMMY);
         builder.read_format(

--- a/perf-event/src/group.rs
+++ b/perf-event/src/group.rs
@@ -109,6 +109,19 @@ impl Group {
             .build_group()
     }
 
+    /// Conveniently create a [Builder] preconfigured for groups.
+    pub fn builder() -> Builder<'static> {
+        let mut builder = Builder::new(Software::DUMMY);
+        builder.read_format(
+            ReadFormat::GROUP
+                | ReadFormat::TOTAL_TIME_ENABLED
+                | ReadFormat::TOTAL_TIME_RUNNING
+                | ReadFormat::ID,
+        );
+
+        builder
+    }
+
     /// Access the internal counter for this group.
     pub fn as_counter(&self) -> &Counter {
         &self.0


### PR DESCRIPTION
Hello there! I am a happy user of this library. I've got a small contribution to make.

I added a new method to `Group` that shortcuts creating an appropriate `Builder`.

If you aren't familiar with the `perf_event_open` API it will be frustrating to try figure out why this code blows up, reporting only `Error: Invalid argument (os error 22) `.

This method makes it easier and clearer to create groups with non-default settings.

```rust
use perf_event::events::Raw;
use perf_event::{Builder, Group};

fn main() -> anyhow::Result<()> {
    let mut group = Group::new()?;

    // The change I'm proposing:
    // let mut group = Group::builder().one_cpu(0).build_group()?;

    let port_usage = group.add(&Builder::new(Raw::new(0xA1 | (0x80 << 8))).one_cpu(0))?;
    //                                                                     ^^^ this causes the code to explode, which goes against the least surprise principle.

    group.enable()?;
    let mut fac = 1;
    for n in 1..=10 {
        fac *= n;
    }
    let counts = group.read()?;

    println!("{}", fac);
    println!("{}", counts[&port_usage]);

    Ok(())
}
```