### PR TITLE
Access perf_event_attr fields directly instead of via anon fields

### DIFF
--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -28,9 +28,7 @@ c-enum = "0.2.0"
 libc = "0.2"
 memmap2 = "0.9"
 perf-event-data = "0.1.1"
-
-[dependencies.perf-event-open-sys2]
-version = "5.0"
+perf-event-open-sys2 = "5.0.4"
 
 [dev-dependencies]
 nix = { version = "0.29", features = ["process", "feature"] }

--- a/perf-event/src/builder.rs
+++ b/perf-event/src/builder.rs
@@ -583,7 +583,7 @@ impl<'a> Builder<'a> {
     /// [`sample_frequency`]: Builder::sample_frequency
     pub fn sample_period(&mut self, period: u64) -> &mut Self {
         self.attrs.set_freq(0);
-        self.attrs.__bindgen_anon_1.sample_period = period;
+        self.attrs.sample_period = period;
         self
     }
 
@@ -604,7 +604,7 @@ impl<'a> Builder<'a> {
     /// [`sample_period`]: Builder::sample_period
     pub fn sample_frequency(&mut self, frequency: u64) -> &mut Self {
         self.attrs.set_freq(1);
-        self.attrs.__bindgen_anon_1.sample_freq = frequency;
+        self.attrs.sample_freq = frequency;
         self
     }
 
@@ -642,7 +642,7 @@ impl<'a> Builder<'a> {
     /// [`Sampler::next_blocking`]: crate::Sampler::next_blocking
     pub fn wakeup_watermark(&mut self, watermark: usize) -> &mut Self {
         self.attrs.set_watermark(1);
-        self.attrs.__bindgen_anon_2.wakeup_watermark = watermark as _;
+        self.attrs.wakeup_watermark = watermark as _;
         self
     }
 
@@ -662,7 +662,7 @@ impl<'a> Builder<'a> {
     /// [`Sampler::next_blocking`]: crate::Sampler::next_blocking
     pub fn wakeup_events(&mut self, events: usize) -> &mut Self {
         self.attrs.set_watermark(0);
-        self.attrs.__bindgen_anon_2.wakeup_events = events as _;
+        self.attrs.wakeup_events = events as _;
         self
     }
 

--- a/perf-event/src/events/breakpoint.rs
+++ b/perf-event/src/events/breakpoint.rs
@@ -166,15 +166,15 @@ impl Event for Breakpoint {
         match self {
             Self::Data { access, addr, len } => {
                 attr.bp_type = access.bits();
-                attr.__bindgen_anon_3.bp_addr = addr;
-                attr.__bindgen_anon_4.bp_len = len;
+                attr.bp_addr = addr;
+                attr.bp_len = len;
             }
             Self::Code { addr } => {
                 attr.bp_type = bindings::HW_BREAKPOINT_X;
-                attr.__bindgen_anon_3.bp_addr = addr;
+                attr.bp_addr = addr;
                 // According to the perf_event_open man page, execute breakpoints
                 // should set len to sizeof(long).
-                attr.__bindgen_anon_4.bp_len = std::mem::size_of::<libc::c_long>() as _;
+                attr.bp_len = std::mem::size_of::<libc::c_long>() as _;
             }
         }
     }

--- a/perf-event/src/events/dynamic.rs
+++ b/perf-event/src/events/dynamic.rs
@@ -34,8 +34,8 @@ impl Event for Dynamic {
     fn update_attrs(self, attr: &mut perf_event_attr) {
         attr.type_ = self.ty;
         attr.config = self.config;
-        attr.__bindgen_anon_3.config1 = self.config1;
-        attr.__bindgen_anon_4.config2 = self.config2;
+        attr.config1 = self.config1;
+        attr.config2 = self.config2;
     }
 }
 

--- a/perf-event/src/events/probe.rs
+++ b/perf-event/src/events/probe.rs
@@ -33,13 +33,13 @@ impl Event for Probe {
         attr.config = self.retprobe.into();
         match self.target {
             ProbeTarget::Addr(addr) => {
-                attr.__bindgen_anon_3.kprobe_func = 0;
-                attr.__bindgen_anon_4.kprobe_addr = addr;
+                attr.kprobe_func = 0;
+                attr.kprobe_addr = addr;
                 None
             }
             ProbeTarget::Func { name, offset } => {
-                attr.__bindgen_anon_3.kprobe_func = name.as_ptr() as usize as u64;
-                attr.__bindgen_anon_4.probe_offset = offset;
+                attr.kprobe_func = name.as_ptr() as usize as u64;
+                attr.probe_offset = offset;
                 Some(Arc::new(name))
             }
         }

--- a/perf-event/src/events/raw.rs
+++ b/perf-event/src/events/raw.rs
@@ -82,7 +82,7 @@ impl Event for Raw {
     fn update_attrs(self, attr: &mut bindings::perf_event_attr) {
         attr.type_ = bindings::PERF_TYPE_RAW;
         attr.config = self.config;
-        attr.__bindgen_anon_3.config1 = self.config1;
-        attr.__bindgen_anon_4.config2 = self.config2;
+        attr.config1 = self.config1;
+        attr.config2 = self.config2;
     }
 }


### PR DESCRIPTION
Now that perf-event-open-sys2 supports directly accessing fields within inline unions in perf_event_attr we can take advantage of that to perform some cleanup on internal code in this crate.