### PR TITLE
Update all manpage links to point to mankier.com

### DIFF
--- a/perf-event-open-sys/src/bindings_aarch64.rs
+++ b/perf-event-open-sys/src/bindings_aarch64.rs
@@ -10,7 +10,7 @@
 //! [the source code][src] for the C identifier name and see what `bindgen` did
 //! with it.
 //!
-//! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+//! [man]: https://www.mankier.com/2/perf_event_open
 //! [bindgen]: https://github.com/rust-lang/rust-bindgen
 //! [src]: ../../src/perf_event_open_sys/bindings.rs.html
 

--- a/perf-event-open-sys/src/bindings_header.rs
+++ b/perf-event-open-sys/src/bindings_header.rs
@@ -10,7 +10,7 @@
 //! [the source code][src] for the C identifier name and see what `bindgen` did
 //! with it.
 //!
-//! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+//! [man]: https://www.mankier.com/2/perf_event_open
 //! [bindgen]: https://github.com/rust-lang/rust-bindgen
 //! [src]: ../../src/perf_event_open_sys/bindings.rs.html
 

--- a/perf-event-open-sys/src/bindings_x86_64.rs
+++ b/perf-event-open-sys/src/bindings_x86_64.rs
@@ -10,7 +10,7 @@
 //! [the source code][src] for the C identifier name and see what `bindgen` did
 //! with it.
 //!
-//! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+//! [man]: https://www.mankier.com/2/perf_event_open
 //! [bindgen]: https://github.com/rust-lang/rust-bindgen
 //! [src]: ../../src/perf_event_open_sys/bindings.rs.html
 

--- a/perf-event-open-sys/src/functions.rs
+++ b/perf-event-open-sys/src/functions.rs
@@ -34,7 +34,7 @@ use std::os::raw::{c_int, c_ulong};
 /// `perf_event_attr` struct. The measurements and other behaviors its
 /// contents request must be safe.
 ///
-/// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+/// [man]: https://www.mankier.com/2/perf_event_open
 pub unsafe fn perf_event_open(
     attrs: *mut bindings::perf_event_attr,
     pid: pid_t,
@@ -60,7 +60,7 @@ pub mod ioctls {
     //!
     //! On error, these return `-1` and set the C `errno` value.
     //!
-    //! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    //! [man]: https://www.mankier.com/2/perf_event_open
     use crate::bindings::{self, perf_event_attr, perf_event_query_bpf};
     use std::os::raw::{c_char, c_int, c_uint, c_ulong};
 

--- a/perf-event-open-sys/src/lib.rs
+++ b/perf-event-open-sys/src/lib.rs
@@ -174,7 +174,7 @@
 //!
 //! [`bindings`]: bindings/index.html
 //! [`ioctls`]: ioctls/index.html
-//! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+//! [man]: https://www.mankier.com/2/perf_event_open
 //! [`perf_event`]: https://crates.io/crates/perf_event
 
 mod attr;

--- a/perf-event/README.md
+++ b/perf-event/README.md
@@ -8,7 +8,7 @@ are available in Linux.
 > has been updated to support more features of the [`perf_event_open`][man]
 > API.
 
-[man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+[man]:https://www.mankier.com/2/perf_event_open
 [jb-perf-event]: https://github.com/jimblandy/perf-event
 
 ## Getting Started

--- a/perf-event/src/builder.rs
+++ b/perf-event/src/builder.rs
@@ -194,7 +194,7 @@ impl<'a> Builder<'a> {
     /// [`Group::add`]: crate::Group::add
     /// [`enable`]: crate::Counter::enable
     /// [`enable_on_exec`]: Builder::enable_on_exec
-    /// [0]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [0]: https://www.mankier.com/2/perf_event_open
     pub fn build(&self) -> std::io::Result<Counter> {
         Counter::new_internal(self.build_impl(None)?, ParseConfig::from(self.attrs))
     }
@@ -235,7 +235,7 @@ impl<'a> Builder<'a> {
     ///   [`UnsupportedOptionsError`]. This allows you to access the size of the
     ///   [`perf_event_attr`] struct that the kernel was expecting.
     ///
-    /// [0]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [0]: https://www.mankier.com/2/perf_event_open
     ///
     /// # Panics
     /// This method panics if `attrs.size` has been set to a value larger than
@@ -350,7 +350,7 @@ impl<'a> Builder<'a> {
     /// Observe the process with the given process id. This requires
     /// [`CAP_SYS_PTRACE`][man-capabilities] capabilities.
     ///
-    /// [man-capabilities]: http://man7.org/linux/man-pages/man7/capabilities.7.html
+    /// [man-capabilities]: https://www.mankier.com/7/capabilities
     pub fn observe_pid(&mut self, pid: pid_t) -> &mut Self {
         self.who = EventPid::Other(pid);
         self
@@ -370,7 +370,7 @@ impl<'a> Builder<'a> {
     /// [`any_cpu`]: Builder::any_cpu
     /// [`build`]: Builder::build
     /// [`one_cpu`]: Builder::one_cpu
-    /// [cap]: http://man7.org/linux/man-pages/man7/capabilities.7.html
+    /// [cap]: https://www.mankier.com/7/capabilities
     pub fn any_pid(&mut self) -> &mut Self {
         self.who = EventPid::Any;
         self
@@ -380,7 +380,7 @@ impl<'a> Builder<'a> {
     /// `cgroup` argument should be a `File` referring to the cgroup's directory
     /// in the cgroupfs filesystem.
     ///
-    /// [man-cgroups]: http://man7.org/linux/man-pages/man7/cgroups.7.html
+    /// [man-cgroups]: https://www.mankier.com/7/cgroups
     pub fn observe_cgroup(&mut self, cgroup: &'a File) -> &mut Self {
         self.who = EventPid::CGroup(cgroup);
         self
@@ -432,7 +432,7 @@ impl<'a> Builder<'a> {
     /// ```
     ///
     /// [`SampleFlag`]: crate::SampleFlag
-    /// [manpage]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
     pub fn sample(&mut self, sample: SampleFlag) -> &mut Self {
         self.attrs.sample_type |= sample.bits();
         self
@@ -683,7 +683,7 @@ impl<'a> Builder<'a> {
     ///
     /// This method is mutually exclusive with [`wakeup_watermark`].
     ///
-    /// [manpage]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
     /// [`wakeup_watermark`]: Builder::wakeup_watermark
     /// [`Sampler::next_blocking`]: crate::Sampler::next_blocking
     pub fn wakeup_events(&mut self, events: usize) -> &mut Self {
@@ -718,7 +718,7 @@ impl<'a> Builder<'a> {
     /// See the [manpage] for the exact fields that are included and which
     /// records include the trailer.
     ///
-    /// [manpage]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
     pub fn sample_id_all(&mut self, sample_id_all: bool) -> &mut Self {
         self.attrs.set_sample_id_all(sample_id_all.into());
         self
@@ -730,7 +730,7 @@ impl<'a> Builder<'a> {
     ///
     /// See the [manpage] for more documentation.
     ///
-    /// [manpage]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
     pub fn exclude_host(&mut self, exclude_host: bool) -> &mut Self {
         self.attrs.set_exclude_host(exclude_host.into());
         self
@@ -742,7 +742,7 @@ impl<'a> Builder<'a> {
     ///
     /// See the [manpage] for more documentation.
     ///
-    /// [manpage]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [manpage]: https://www.mankier.com/2/perf_event_open
     pub fn exclude_guest(&mut self, exclude_guest: bool) -> &mut Self {
         self.attrs.set_exclude_guest(exclude_guest.into());
         self
@@ -791,7 +791,7 @@ impl<'a> Builder<'a> {
     /// See [`Clock`] and the [`clock_getttime(2)`][0] manpage for
     /// documentation on what the different clock values mean.
     ///
-    /// [0]: https://man7.org/linux/man-pages/man2/clock_gettime.2.html
+    /// [0]: https://www.mankier.com/2/clock_gettime
     pub fn clockid(&mut self, clockid: impl Into<Option<Clock>>) -> &mut Self {
         let clockid = clockid.into();
         self.attrs.set_use_clockid(clockid.is_some().into());

--- a/perf-event/src/events/breakpoint.rs
+++ b/perf-event/src/events/breakpoint.rs
@@ -83,7 +83,7 @@ bitflags! {
 ///   manpage indicates that the only valid values for `bp_len` are 1, 2, 4, and
 ///   8.
 ///
-/// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+/// [man]: https://www.mankier.com/2/perf_event_open
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Breakpoint {
     /// Data breakpoint. Triggers when code reads or writes to the memory area

--- a/perf-event/src/events/cache.rs
+++ b/perf-event/src/events/cache.rs
@@ -80,7 +80,7 @@ c_enum! {
     /// `PERF_COUNT_HW_CACHE_...` constant supported by the [`perf_event_open`][man]
     /// system call.
     ///
-    /// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [man]: https://www.mankier.com/2/perf_event_open
     #[repr(transparent)]
     #[derive(Clone, Copy, Eq, PartialEq, Hash)]
     pub enum CacheId : u8 {
@@ -115,7 +115,7 @@ c_enum! {
     /// `PERF_COUNT_HW_CACHE_OP_...` constant supported by the
     /// [`perf_event_open`][man] system call.
     ///
-    /// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [man]: https://www.mankier.com/2/perf_event_open
     #[repr(transparent)]
     #[derive(Clone, Copy, Eq, PartialEq, Hash)]
     pub enum CacheOp : u8 {
@@ -142,7 +142,7 @@ c_enum! {
     /// `PERF_COUNT_HW_CACHE_RESULT_...` constant supported by the
     /// [`perf_event_open`][man] system call.
     ///
-    /// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [man]: https://www.mankier.com/2/perf_event_open
     #[repr(transparent)]
     #[derive(Clone, Copy, Eq, PartialEq, Hash)]
     pub enum CacheResult : u8 {

--- a/perf-event/src/events/hardware.rs
+++ b/perf-event/src/events/hardware.rs
@@ -15,7 +15,7 @@ c_enum! {
     /// Each variant of this enum corresponds to a particular `PERF_COUNT_HW_`...
     /// value supported by the [`perf_event_open`][man] system call.
     ///
-    /// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [man]: https://www.mankier.com/2/perf_event_open
     #[repr(transparent)]
     #[derive(Clone, Copy, Eq, PartialEq, Hash)]
     pub enum Hardware : u64 {

--- a/perf-event/src/events/software.rs
+++ b/perf-event/src/events/software.rs
@@ -9,7 +9,7 @@ c_enum! {
     /// Each variant of this enum corresponds to a particular `PERF_COUNT_SW_`...
     /// value supported by the [`perf_event_open`][man] system call.
     ///
-    /// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [man]: https://www.mankier.com/2/perf_event_open
     #[repr(transparent)]
     #[derive(Clone, Copy, Eq, PartialEq, Hash)]
     pub enum Software : u64 {

--- a/perf-event/src/flags.rs
+++ b/perf-event/src/flags.rs
@@ -71,7 +71,7 @@ pub enum SampleSkid {
 /// See the [`clock_gettime(2)`][0] manpage for the full documentation on what
 /// each clock value actually means.
 ///
-/// [0]: https://man7.org/linux/man-pages/man2/clock_gettime.2.html
+/// [0]: https://www.mankier.com/2/clock_gettime
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct Clock(libc::clockid_t);

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -73,7 +73,7 @@
 //! If you find yourself in need of something this crate doesn't support, please
 //! consider submitting a pull request.
 //!
-//! [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+//! [man]: https://www.mankier.com/2/perf_event_open
 
 #![cfg_attr(debug_assertions, warn(missing_docs))]
 #![cfg_attr(not(debug_assertions), deny(missing_docs))]
@@ -625,7 +625,7 @@ impl Counter {
     /// [`read`]: crate::Group::read
     /// [`TOTAL_TIME_ENABLED`]: ReadFormat::TOTAL_TIME_ENABLED
     /// [`TOTAL_TIME_RUNNING`]: ReadFormat::TOTAL_TIME_RUNNING
-    /// [man]: http://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [man]: https://www.mankier.com/2/perf_event_open
     pub fn read_count_and_time(&mut self) -> io::Result<CountAndTime> {
         let data = self.read_full()?;
 

--- a/perf-event/src/sampler.rs
+++ b/perf-event/src/sampler.rs
@@ -30,7 +30,7 @@ used_in_docs!(Hardware);
 /// [`perf_event_open` man page][0] for documentation on how the sample records
 /// are represented in memory.
 ///
-/// [0]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+/// [0]: https://www.mankier.com/2/perf_event_open
 pub struct Sampler {
     counter: Counter,
     mmap: memmap2::MmapRaw,
@@ -90,7 +90,7 @@ impl Sampler {
     /// on the [`perf_event_open`][man] manpage for details on how to do this.
     ///
     /// [`next_blocking`]: Self::next_blocking
-    /// [man]: https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+    /// [man]: https://www.mankier.com/2/perf_event_open
     pub fn next_record(&mut self) -> Option<Record> {
         use std::{mem, ptr, slice};
 


### PR DESCRIPTION
man7.org is great but hasn't been updated in a few years. Most manpages don't really change that often so this usually doesn't matter that much but the perf_event_open manpage changes fairly frequently. This means that the manpage at man7.org is missing a few options and will continue to get worse as time goes on.

mankier.com seems to be reliably updated to the most recent kernel version and has been going for about a decade now so it should be reliable enough to link to from the documentation.