### PR TITLE
Rework and simplify internals

### DIFF
--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -29,6 +29,7 @@ libc = "0.2"
 memmap2 = "0.9"
 perf-event-data = "0.1.8"
 perf-event-open-sys2 = "5.0.4"
+thiserror = "2.0.14"
 
 [dev-dependencies]
 ctrlc = "3.4.5"

--- a/perf-event/Cargo.toml
+++ b/perf-event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf-event2"
-version = "0.7.4"
+version = "0.8.0"
 description = "A Rust interface to Linux performance monitoring"
 license = "MIT OR Apache-2.0"
 authors = ["Sean Lynch <sean@lynches.ca>", "Jim Blandy <jimb@red-bean.com>"]

--- a/perf-event/examples/tracepoint.rs
+++ b/perf-event/examples/tracepoint.rs
@@ -1,0 +1,21 @@
+use perf_event::data::Record;
+use perf_event::events::Tracepoint;
+use perf_event::{Builder, CpuPid};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut counter = Builder::new(Tracepoint::with_name("net/net_dev_xmit")?)
+        .targeting(CpuPid::AnyProcessOneCpu { cpu: 0 })
+        .build()?
+        .sampled(8192)?;
+
+    counter.enable()?;
+
+    while let Some(record) = counter.next_blocking(None) {
+        println!("received event");
+        if let Ok(Record::Sample(sample)) = record.parse_record() {
+            dbg!(sample);
+        }
+    }
+
+    Ok(())
+}

--- a/perf-event/src/builder.rs
+++ b/perf-event/src/builder.rs
@@ -267,7 +267,27 @@ impl CpuPid {
 // Methods that actually do work on the builder and aren't just setting
 // config values.
 impl Builder {
-    /// Return a new `Builder`, with all parameters set to their defaults.
+    /// Return a new `Builder`, with all parameters set to their defaults for
+    /// the given event type. Each event type sets opinionated, unique
+    /// defaults. The defaults are chosen so as to make the resultant Builder
+    /// maximally useful. See the documentation for [crate::events::Tracepoint]
+    /// as an example.
+    ///
+    /// ```
+    /// # use perf_event::events::Tracepoint;
+    /// # use perf_event::Builder;
+    /// # use perf_event::events::Hardware;
+    /// let sched_switch = Tracepoint::with_id(0xabcd);
+    /// let cpu_cycles = Hardware::CPU_CYCLES;
+    ///
+    /// // b1 has defaults sensible for tracepoints.
+    /// let b1 = Builder::new(sched_switch);
+    /// assert_eq!(b1.attrs().wakeup_events, 1);
+    ///
+    /// // b2 has defaults sensible for hardware events.
+    /// let b2 = Builder::new(cpu_cycles);
+    /// assert_eq!(b2.attrs().wakeup_events, 0);
+    /// ```
     ///
     /// Return a new `Builder` for the specified event.
     pub fn new<E: Event>(event: E) -> Self {

--- a/perf-event/src/events/hardware.rs
+++ b/perf-event/src/events/hardware.rs
@@ -55,5 +55,8 @@ impl Event for Hardware {
     fn update_attrs(self, attr: &mut bindings::perf_event_attr) {
         attr.type_ = bindings::PERF_TYPE_HARDWARE;
         attr.config = self.into();
+        attr.set_disabled(1);
+        attr.set_exclude_kernel(1);
+        attr.set_exclude_hv(1);
     }
 }

--- a/perf-event/src/events/mod.rs
+++ b/perf-event/src/events/mod.rs
@@ -91,6 +91,6 @@ pub trait Event: Sized {
 ///
 /// This is automatically implemented for any type which is both `Send` and
 /// `Sync`.
-pub trait EventData: Send + Sync {}
+pub trait EventData: Send + Sync + 'static {}
 
-impl<T: Send + Sync> EventData for T {}
+impl<T: Send + Sync + 'static> EventData for T {}

--- a/perf-event/src/events/tracepoint.rs
+++ b/perf-event/src/events/tracepoint.rs
@@ -22,6 +22,14 @@ use crate::events::Event;
 /// [`perf probe`].
 ///
 /// [`perf probe`]: https://man7.org/linux/man-pages/man1/perf-probe.1.html
+///
+/// By default [Self::update_attrs] updates the defaults to those that make
+/// sense for tracepoints:
+/// 1. Named, static tracepoints are intrinsically kernel events, so
+///    `exclude_kernel` is set to false.
+/// 2. The watermark and wakeup values are set so that
+///    [crate::Sampler::next_blocking] works by default.
+/// 3. Sampling period is set to 1 - all tracepoints trigger.
 #[derive(Clone, Copy, Debug)]
 pub struct Tracepoint {
     id: u64,

--- a/perf-event/src/events/tracepoint.rs
+++ b/perf-event/src/events/tracepoint.rs
@@ -1,8 +1,9 @@
+use std::io;
 use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
-use std::{fmt, io};
 
 use perf_event_open_sys::bindings;
+use thiserror::Error;
 
 use crate::events::Event;
 
@@ -57,14 +58,14 @@ impl Tracepoint {
     /// # let _ = run();
     /// ```
     pub fn with_name(name: impl AsRef<Path>) -> io::Result<Self> {
-        let mut path = PathBuf::from("/sys/kernel/debug/tracing/events");
-        path.push(name.as_ref());
-        path.push("id");
+        let path = PathBuf::from("/sys/kernel/debug/tracing/events")
+            .join(&name)
+            .join("id");
 
         let id = std::fs::read_to_string(&path)?
             .trim_end()
             .parse()
-            .map_err(move |e| io::Error::other(UnparseableIdFile::new(path, e)))?;
+            .map_err(|source| io::Error::other(UnparseableIdFile { path, source }))?;
 
         Ok(Self::with_id(id))
     }
@@ -78,33 +79,19 @@ impl Tracepoint {
 impl Event for Tracepoint {
     fn update_attrs(self, attr: &mut bindings::perf_event_attr) {
         attr.type_ = bindings::PERF_TYPE_TRACEPOINT;
+        attr.set_exclude_kernel(0);
+        attr.sample_type |= crate::SampleFlag::RAW.bits();
+        attr.sample_period = 1;
         attr.config = self.id;
+        attr.set_watermark(0);
+        attr.wakeup_events = 1;
     }
 }
 
-#[derive(Debug)]
-struct UnparseableIdFile {
+#[derive(Debug, Error)]
+#[error("unparseable tracepoint id file `{path:?}`")]
+pub struct UnparseableIdFile {
     path: PathBuf,
+    #[source]
     source: ParseIntError,
-}
-
-impl UnparseableIdFile {
-    fn new(path: PathBuf, source: ParseIntError) -> Self {
-        Self { path, source }
-    }
-}
-
-impl fmt::Display for UnparseableIdFile {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!(
-            "unparseable tracepoint id file `{}`",
-            self.path.display()
-        ))
-    }
-}
-
-impl std::error::Error for UnparseableIdFile {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        Some(&self.source)
-    }
 }

--- a/perf-event/src/group.rs
+++ b/perf-event/src/group.rs
@@ -119,7 +119,7 @@ impl Group {
     ///
     /// [`read_format`]: Builder::read_format
     /// [`build_group`]: Builder::build_group
-    pub fn builder() -> Builder<'static> {
+    pub fn builder() -> Builder {
         let mut builder = Builder::new(Software::DUMMY);
         builder.read_format(
             ReadFormat::GROUP

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! Linux's `perf_event_open` API can report all sorts of things this crate
 //! doesn't yet understand: stack traces, logs of executable and shared library
-//! activity, tracepoints, kprobes, uprobes, and so on. And beyond the counters
+//! activity, kprobes, uprobes, and so on. And beyond the counters
 //! in the kernel header files, there are others that can only be found at
 //! runtime by consulting `sysfs`, specific to particular processors and
 //! devices. For example, modern Intel processors have counters that measure
@@ -142,7 +142,7 @@ pub use perf_event_data as data;
 #[cfg(not(feature = "hooks"))]
 use perf_event_open_sys as sys;
 
-pub use crate::builder::{Builder, UnsupportedOptionsError};
+pub use crate::builder::{Builder, CpuPid, UnsupportedOptionsError};
 #[doc(inline)]
 pub use crate::data::{ReadFormat, SampleFlags as SampleFlag};
 pub use crate::flags::{Clock, SampleBranchFlag, SampleSkid};
@@ -884,10 +884,9 @@ mod tests {
 
         // CPU_CLOCK is literally always supported so we don't have to worry
         // about test failures when in VMs.
-        let builder = Builder::new(events::Software::CPU_CLOCK)
-            // There should _hopefully_ never be a system with this many CPUs.
-            .one_cpu(i32::MAX as usize)
-            .clone();
+        let mut prep = Builder::new(events::Software::CPU_CLOCK);
+        // There should _hopefully_ never be a system with this many CPUs.
+        let builder = prep.one_cpu(i32::MAX as usize);
 
         match builder.build() {
             Ok(_) => panic!("counter construction was not supposed to succeed"),

--- a/perf-event/src/lib.rs
+++ b/perf-event/src/lib.rs
@@ -884,9 +884,11 @@ mod tests {
 
         // CPU_CLOCK is literally always supported so we don't have to worry
         // about test failures when in VMs.
-        let mut prep = Builder::new(events::Software::CPU_CLOCK);
         // There should _hopefully_ never be a system with this many CPUs.
-        let builder = prep.one_cpu(i32::MAX as usize);
+        let builder = Builder::new(events::Software::CPU_CLOCK)
+            // There should _hopefully_ never be a system with this many CPUs.
+            .one_cpu(i32::MAX as usize)
+            .clone();
 
         match builder.build() {
             Ok(_) => panic!("counter construction was not supposed to succeed"),


### PR DESCRIPTION
This change fixes a few things in one go. I wrote up a blog post on my adventures with this crate: https://roci.co.za/posts/hunting-bugs-in-perf-event2

1. The parameters set by implementations of `Event` were not being respected. This is now fixed. More importantly, the events in this crate now set sensible defaults. For instance, static kernel tracepoints are intrinsically kernel-level events, so they are now automatically marked as such. This fixes the bug where `poll` hung indefinitely when asking for a tracepoint. **Tracepoints now work out of the box**. If anyone needs to explicitly set these parameters _back_ to the non-sensible defaults, they still can.
1. I added a tracepoint example and removed the comment saying that they do not work.
1. I removed some code that `thiserror` could generate, and took a dependency on it.
1. I introduced a new, painfully explicit, lifetime-free enum into the public API that makes it easier to _ask for what you want_. It has the knock-on effect of obviating the need for `Builder` to carry a lifetime. This works because on Linux you can liberally and infallibly clone file descriptors pointing at cgroups.
1. I tightened the lifetime bounds on what can go into `EventData`, because non-static lifetimes cannot reasonably be justified.